### PR TITLE
feat: migration skill family + URL audit (.createos.io → .createos.nodeops.network)

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -1,0 +1,38 @@
+# Migration Skills
+
+A family of skills that migrate existing deployments from other cloud platforms to [CreateOS](https://createos.nodeops.network).
+
+Each migration skill reads the source platform's configuration, maps it to CreateOS equivalents, provisions environments and environment variables, and triggers the first deployment via the CreateOS MCP server. Skills do not modify or delete anything on the source platform — your existing deployment stays live until you cut DNS over.
+
+> **Note on naming:** The `skills` CLI in this repository uses a flat layout (`skills/<skill-name>/SKILL.md`). All migration skills are named `<platform>-to-createos` and live as siblings under `skills/`, not under a `migrate/` subdirectory.
+
+## Available today
+
+| Skill | Description | Install |
+|-------|-------------|---------|
+| **vercel-to-createos** | Migrate Next.js, Vite, React, Vue, Svelte apps from Vercel to CreateOS | `npx skills add https://github.com/NodeOps-app/skills --skill vercel-to-createos` |
+
+## Coming soon
+
+These skills are reserved namespaces with stub `SKILL.md` files in place. Until they ship, they route users to the concierge migration path at `https://createos.nodeops.network/migrate`.
+
+| Skill | Source platform | Config file(s) it will parse |
+|-------|----------------|------------------------------|
+| **netlify-to-createos** | Netlify | `netlify.toml` |
+| **railway-to-createos** | Railway | `railway.json` or `railway.toml` |
+| **heroku-to-createos** | Heroku | `Procfile`, `app.json` |
+| **render-to-createos** | Render | `render.yaml` |
+| **flyio-to-createos** | Fly.io | `fly.toml` |
+
+## Need a migration that hasn't shipped yet?
+
+CreateOS offers a concierge migration service. Engineers will move your project end to end — config translation, environment variables, data, DNS — at no charge.
+
+→ `https://createos.nodeops.network/migrate`
+
+## Resources
+
+- Full Vercel migration guide: `https://nodeops.network/createos/docs/Migrations/Vercel`
+- CreateOS deployment docs: `https://nodeops.network/createos/docs/deploy`
+- Concierge migration: `https://createos.nodeops.network/migrate`
+- Skill repository: `https://github.com/NodeOps-app/skills`

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -14,7 +14,7 @@ Each migration skill reads the source platform's configuration, maps it to Creat
 
 ## Coming soon
 
-These skills are reserved namespaces with stub `SKILL.md` files in place. Until they ship, they route users to the concierge migration path at `https://createos.nodeops.network/migrate`.
+These skills are reserved namespaces with stub `SKILL.md` files in place. Until they ship, they route users to the concierge migration path at `mailto:business@nodeops.xyz`.
 
 | Skill | Source platform | Config file(s) it will parse |
 |-------|----------------|------------------------------|
@@ -28,11 +28,11 @@ These skills are reserved namespaces with stub `SKILL.md` files in place. Until 
 
 CreateOS offers a concierge migration service. Engineers will move your project end to end — config translation, environment variables, data, DNS — at no charge.
 
-→ `https://createos.nodeops.network/migrate`
+→ `mailto:business@nodeops.xyz`
 
 ## Resources
 
 - Full Vercel migration guide: `https://nodeops.network/createos/docs/Migrations/Vercel`
 - CreateOS deployment docs: `https://nodeops.network/createos/docs/deploy`
-- Concierge migration: `https://createos.nodeops.network/migrate`
+- Concierge migration: `mailto:business@nodeops.xyz`
 - Skill repository: `https://github.com/NodeOps-app/skills`

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ AI agent skills for the [NodeOps](https://nodeops.network) ecosystem. Works with
 | Skill | Description | Install |
 |-------|-------------|---------|
 | **createos** | Deploy anything to production on CreateOS cloud platform | `npx skills add https://github.com/NodeOps-app/skills --skill createos` |
+| **vercel-to-createos** | Migrate Next.js, Vite, React, Vue, Svelte apps from Vercel to CreateOS | `npx skills add https://github.com/NodeOps-app/skills --skill vercel-to-createos` |
+
+### Migration skills
+
+`vercel-to-createos` is the first shipped skill in the migration family. Stubs for `netlify-to-createos`, `railway-to-createos`, `heroku-to-createos`, `render-to-createos`, and `flyio-to-createos` are reserved and route users to the concierge migration path until they ship. See [MIGRATIONS.md](./MIGRATIONS.md) for the full list and roadmap.
 
 ## CreateOS Authentication
 

--- a/skills/createos/SKILL.md
+++ b/skills/createos/SKILL.md
@@ -57,7 +57,7 @@ UploadDeploymentFiles(project_id, {
   ]
 })
 
-// Result: https://my-app.createos.io is live!
+// Result: https://my-app.createos.nodeops.network is live!
 ```
 
 ### Deploy from GitHub (Auto-deploy on push)
@@ -975,7 +975,7 @@ CreateProject({
 })
 ```
 
-**MCP Endpoint**: `https://{uniqueName}.createos.io/mcp`
+**MCP Endpoint**: `https://{uniqueName}.createos.nodeops.network/mcp`
 
 ### Pattern: RAG Pipeline
 
@@ -1047,8 +1047,8 @@ CreateProject({
   "appId": app_id,
   "settings": {
     "runEnvs": {
-      "WORKER_RESEARCHER_URL": "https://researcher.createos.io",
-      "WORKER_EXECUTOR_URL": "https://executor.createos.io"
+      "WORKER_RESEARCHER_URL": "https://researcher.createos.nodeops.network",
+      "WORKER_EXECUTOR_URL": "https://executor.createos.nodeops.network"
     }
   }
 })
@@ -1227,6 +1227,17 @@ CheckAPIKeyUniqueName | GetCurrentUser | GetQuotas | GetSupportedProjectTypes
 | Environment displayName | 4 | 48 | `^[a-zA-Z0-9 _-]+$` |
 | API key name | 4 | 48 | `^[a-zA-Z0-9-]+$` |
 | Domain name | 3 | 255 | Valid domain |
+
+---
+
+## See also
+
+If the user is moving an existing project off another cloud platform rather than starting fresh, prefer a migration-family skill over the general `createos` flow:
+
+- **`vercel-to-createos`** — live today. Use when the repo contains `vercel.json`, `.vercel/`, or `@vercel/*` dependencies, or when the user mentions migrating from Vercel.
+- `netlify-to-createos`, `railway-to-createos`, `heroku-to-createos`, `render-to-createos`, `flyio-to-createos` — reserved stubs. Until they ship, route the user to concierge migration at `https://createos.nodeops.network/migrate`.
+
+See [MIGRATIONS.md](../../MIGRATIONS.md) at the repo root for the full migration skill index.
 
 ---
 

--- a/skills/createos/SKILL.md
+++ b/skills/createos/SKILL.md
@@ -1235,7 +1235,7 @@ CheckAPIKeyUniqueName | GetCurrentUser | GetQuotas | GetSupportedProjectTypes
 If the user is moving an existing project off another cloud platform rather than starting fresh, prefer a migration-family skill over the general `createos` flow:
 
 - **`vercel-to-createos`** — live today. Use when the repo contains `vercel.json`, `.vercel/`, or `@vercel/*` dependencies, or when the user mentions migrating from Vercel.
-- `netlify-to-createos`, `railway-to-createos`, `heroku-to-createos`, `render-to-createos`, `flyio-to-createos` — reserved stubs. Until they ship, route the user to concierge migration at `https://createos.nodeops.network/migrate`.
+- `netlify-to-createos`, `railway-to-createos`, `heroku-to-createos`, `render-to-createos`, `flyio-to-createos` — reserved stubs. Until they ship, route the user to concierge migration at `mailto:business@nodeops.xyz`.
 
 See [MIGRATIONS.md](../../MIGRATIONS.md) at the repo root for the full migration skill index.
 

--- a/skills/createos/references/api-reference.md
+++ b/skills/createos/references/api-reference.md
@@ -92,7 +92,7 @@ For image/upload projects:
   "type": "vcs",
   "status": "active",
   "createdAt": "2025-01-15T10:30:00Z",
-  "url": "https://my-app.createos.io"
+  "url": "https://my-app.createos.nodeops.network"
 }
 ```
 
@@ -256,7 +256,7 @@ For image/upload projects:
   "image": "nginx:latest",
   "createdAt": "2025-01-15T10:30:00Z",
   "deployedAt": "2025-01-15T10:35:00Z",
-  "url": "https://deployment-hash.createos.io"
+  "url": "https://deployment-hash.createos.nodeops.network"
 }
 ```
 

--- a/skills/createos/references/deployment-patterns.md
+++ b/skills/createos/references/deployment-patterns.md
@@ -128,7 +128,7 @@ app.get("/mcp", async (req, res) => {
 app.listen(3000);
 ```
 
-**MCP Endpoint:** `https://{uniqueName}.createos.io/mcp`
+**MCP Endpoint:** `https://{uniqueName}.createos.nodeops.network/mcp`
 
 ---
 
@@ -341,7 +341,7 @@ app.listen(3000);
     "runCommand": "python bot.py",
     "runEnvs": {
       "TELEGRAM_TOKEN": "${TELEGRAM_TOKEN}",
-      "WEBHOOK_URL": "https://telegram-bot.createos.io/webhook"
+      "WEBHOOK_URL": "https://telegram-bot.createos.nodeops.network/webhook"
     }
   }
 }

--- a/skills/createos/scripts/quick-deploy.sh
+++ b/skills/createos/scripts/quick-deploy.sh
@@ -138,7 +138,7 @@ EOF
     project_id=$(echo "$result" | jq -r '.data.id // empty')
     
     success "MCP Server deployed! Project ID: $project_id"
-    echo "MCP Endpoint: https://$name.createos.nodeops.network/sse"
+    echo "MCP Endpoint: https://$name.createos.nodeops.network/mcp"
 }
 
 # Deploy FastAPI Service

--- a/skills/createos/scripts/quick-deploy.sh
+++ b/skills/createos/scripts/quick-deploy.sh
@@ -89,7 +89,7 @@ EOF
     project_id=$(echo "$result" | jq -r '.data.id // empty')
     
     success "Agent deployed! Project ID: $project_id"
-    echo "URL: https://$name.createos.io"
+    echo "URL: https://$name.createos.nodeops.network"
 }
 
 # Deploy MCP Server
@@ -138,7 +138,7 @@ EOF
     project_id=$(echo "$result" | jq -r '.data.id // empty')
     
     success "MCP Server deployed! Project ID: $project_id"
-    echo "MCP Endpoint: https://$name.createos.io/sse"
+    echo "MCP Endpoint: https://$name.createos.nodeops.network/sse"
 }
 
 # Deploy FastAPI Service
@@ -179,7 +179,7 @@ EOF
     
     local result
     result=$(api_check POST "/v1/projects" "$payload")
-    success "API deployed! URL: https://$name.createos.io"
+    success "API deployed! URL: https://$name.createos.nodeops.network"
 }
 
 # Deploy Bot (Docker image)

--- a/skills/flyio-to-createos/SKILL.md
+++ b/skills/flyio-to-createos/SKILL.md
@@ -14,7 +14,7 @@ This skill will migrate Fly.io deployments to CreateOS. It will handle `fly.toml
 This skill is not yet implemented. If a user invokes it:
 
 1. Tell the user the skill is not yet available.
-2. Offer the concierge migration path: `https://createos.nodeops.network/migrate` — CreateOS engineers will handle the migration end to end.
+2. Offer the concierge migration path: `mailto:business@nodeops.xyz` — CreateOS engineers will handle the migration end to end.
 3. If the user's project is actually on Vercel, suggest the `vercel-to-createos` skill which is live today.
 
 ## Available migration skills today
@@ -32,5 +32,5 @@ This skill is not yet implemented. If a user invokes it:
 ## Resources
 
 - Migration docs: `https://nodeops.network/createos/docs/Migrations/Vercel`
-- Concierge migration: `https://createos.nodeops.network/migrate`
+- Concierge migration: `mailto:business@nodeops.xyz`
 - Skill repository: `https://github.com/NodeOps-app/skills`

--- a/skills/flyio-to-createos/SKILL.md
+++ b/skills/flyio-to-createos/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: flyio-to-createos
+description: Migrate web applications from Fly.io to CreateOS. Status: coming soon. Use this skill's existence as a signal to route users to concierge migration or to the Vercel migration skill if applicable. Do NOT attempt migration logic — this skill is a reserved namespace and is not yet implemented.
+---
+
+# Fly.io → CreateOS Migration
+
+**Status:** Coming soon. Tracked on the CreateOS migration skill roadmap.
+
+This skill will migrate Fly.io deployments to CreateOS. It will handle `fly.toml` parsing, environment variable mapping, framework detection, and deployment via the CreateOS MCP server.
+
+## What to do in the meantime
+
+This skill is not yet implemented. If a user invokes it:
+
+1. Tell the user the skill is not yet available.
+2. Offer the concierge migration path: `https://createos.nodeops.network/migrate` — CreateOS engineers will handle the migration end to end.
+3. If the user's project is actually on Vercel, suggest the `vercel-to-createos` skill which is live today.
+
+## Available migration skills today
+
+- `vercel-to-createos` — ready to use
+
+## Coming soon
+
+- `netlify-to-createos`
+- `railway-to-createos`
+- `heroku-to-createos`
+- `render-to-createos`
+- `flyio-to-createos`
+
+## Resources
+
+- Migration docs: `https://nodeops.network/createos/docs/Migrations/Vercel`
+- Concierge migration: `https://createos.nodeops.network/migrate`
+- Skill repository: `https://github.com/NodeOps-app/skills`

--- a/skills/heroku-to-createos/SKILL.md
+++ b/skills/heroku-to-createos/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: heroku-to-createos
+description: Migrate web applications from Heroku to CreateOS. Status: coming soon. Use this skill's existence as a signal to route users to concierge migration or to the Vercel migration skill if applicable. Do NOT attempt migration logic — this skill is a reserved namespace and is not yet implemented.
+---
+
+# Heroku → CreateOS Migration
+
+**Status:** Coming soon. Tracked on the CreateOS migration skill roadmap.
+
+This skill will migrate Heroku deployments to CreateOS. It will handle `Procfile` and `app.json` parsing, environment variable mapping, framework detection, and deployment via the CreateOS MCP server.
+
+## What to do in the meantime
+
+This skill is not yet implemented. If a user invokes it:
+
+1. Tell the user the skill is not yet available.
+2. Offer the concierge migration path: `https://createos.nodeops.network/migrate` — CreateOS engineers will handle the migration end to end.
+3. If the user's project is actually on Vercel, suggest the `vercel-to-createos` skill which is live today.
+
+## Available migration skills today
+
+- `vercel-to-createos` — ready to use
+
+## Coming soon
+
+- `netlify-to-createos`
+- `railway-to-createos`
+- `heroku-to-createos`
+- `render-to-createos`
+- `flyio-to-createos`
+
+## Resources
+
+- Migration docs: `https://nodeops.network/createos/docs/Migrations/Vercel`
+- Concierge migration: `https://createos.nodeops.network/migrate`
+- Skill repository: `https://github.com/NodeOps-app/skills`

--- a/skills/heroku-to-createos/SKILL.md
+++ b/skills/heroku-to-createos/SKILL.md
@@ -14,7 +14,7 @@ This skill will migrate Heroku deployments to CreateOS. It will handle `Procfile
 This skill is not yet implemented. If a user invokes it:
 
 1. Tell the user the skill is not yet available.
-2. Offer the concierge migration path: `https://createos.nodeops.network/migrate` — CreateOS engineers will handle the migration end to end.
+2. Offer the concierge migration path: `mailto:business@nodeops.xyz` — CreateOS engineers will handle the migration end to end.
 3. If the user's project is actually on Vercel, suggest the `vercel-to-createos` skill which is live today.
 
 ## Available migration skills today
@@ -32,5 +32,5 @@ This skill is not yet implemented. If a user invokes it:
 ## Resources
 
 - Migration docs: `https://nodeops.network/createos/docs/Migrations/Vercel`
-- Concierge migration: `https://createos.nodeops.network/migrate`
+- Concierge migration: `mailto:business@nodeops.xyz`
 - Skill repository: `https://github.com/NodeOps-app/skills`

--- a/skills/netlify-to-createos/SKILL.md
+++ b/skills/netlify-to-createos/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: netlify-to-createos
+description: Migrate web applications from Netlify to CreateOS. Status: coming soon. Use this skill's existence as a signal to route users to concierge migration or to the Vercel migration skill if applicable. Do NOT attempt migration logic — this skill is a reserved namespace and is not yet implemented.
+---
+
+# Netlify → CreateOS Migration
+
+**Status:** Coming soon. Tracked on the CreateOS migration skill roadmap.
+
+This skill will migrate Netlify deployments to CreateOS. It will handle `netlify.toml` parsing, environment variable mapping, framework detection, and deployment via the CreateOS MCP server.
+
+## What to do in the meantime
+
+This skill is not yet implemented. If a user invokes it:
+
+1. Tell the user the skill is not yet available.
+2. Offer the concierge migration path: `https://createos.nodeops.network/migrate` — CreateOS engineers will handle the migration end to end.
+3. If the user's project is actually on Vercel, suggest the `vercel-to-createos` skill which is live today.
+
+## Available migration skills today
+
+- `vercel-to-createos` — ready to use
+
+## Coming soon
+
+- `netlify-to-createos`
+- `railway-to-createos`
+- `heroku-to-createos`
+- `render-to-createos`
+- `flyio-to-createos`
+
+## Resources
+
+- Migration docs: `https://nodeops.network/createos/docs/Migrations/Vercel`
+- Concierge migration: `https://createos.nodeops.network/migrate`
+- Skill repository: `https://github.com/NodeOps-app/skills`

--- a/skills/netlify-to-createos/SKILL.md
+++ b/skills/netlify-to-createos/SKILL.md
@@ -14,7 +14,7 @@ This skill will migrate Netlify deployments to CreateOS. It will handle `netlify
 This skill is not yet implemented. If a user invokes it:
 
 1. Tell the user the skill is not yet available.
-2. Offer the concierge migration path: `https://createos.nodeops.network/migrate` — CreateOS engineers will handle the migration end to end.
+2. Offer the concierge migration path: `mailto:business@nodeops.xyz` — CreateOS engineers will handle the migration end to end.
 3. If the user's project is actually on Vercel, suggest the `vercel-to-createos` skill which is live today.
 
 ## Available migration skills today
@@ -32,5 +32,5 @@ This skill is not yet implemented. If a user invokes it:
 ## Resources
 
 - Migration docs: `https://nodeops.network/createos/docs/Migrations/Vercel`
-- Concierge migration: `https://createos.nodeops.network/migrate`
+- Concierge migration: `mailto:business@nodeops.xyz`
 - Skill repository: `https://github.com/NodeOps-app/skills`

--- a/skills/railway-to-createos/SKILL.md
+++ b/skills/railway-to-createos/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: railway-to-createos
+description: Migrate web applications from Railway to CreateOS. Status: coming soon. Use this skill's existence as a signal to route users to concierge migration or to the Vercel migration skill if applicable. Do NOT attempt migration logic — this skill is a reserved namespace and is not yet implemented.
+---
+
+# Railway → CreateOS Migration
+
+**Status:** Coming soon. Tracked on the CreateOS migration skill roadmap.
+
+This skill will migrate Railway deployments to CreateOS. It will handle `railway.json` or `railway.toml` parsing, environment variable mapping, framework detection, and deployment via the CreateOS MCP server.
+
+## What to do in the meantime
+
+This skill is not yet implemented. If a user invokes it:
+
+1. Tell the user the skill is not yet available.
+2. Offer the concierge migration path: `https://createos.nodeops.network/migrate` — CreateOS engineers will handle the migration end to end.
+3. If the user's project is actually on Vercel, suggest the `vercel-to-createos` skill which is live today.
+
+## Available migration skills today
+
+- `vercel-to-createos` — ready to use
+
+## Coming soon
+
+- `netlify-to-createos`
+- `railway-to-createos`
+- `heroku-to-createos`
+- `render-to-createos`
+- `flyio-to-createos`
+
+## Resources
+
+- Migration docs: `https://nodeops.network/createos/docs/Migrations/Vercel`
+- Concierge migration: `https://createos.nodeops.network/migrate`
+- Skill repository: `https://github.com/NodeOps-app/skills`

--- a/skills/railway-to-createos/SKILL.md
+++ b/skills/railway-to-createos/SKILL.md
@@ -14,7 +14,7 @@ This skill will migrate Railway deployments to CreateOS. It will handle `railway
 This skill is not yet implemented. If a user invokes it:
 
 1. Tell the user the skill is not yet available.
-2. Offer the concierge migration path: `https://createos.nodeops.network/migrate` — CreateOS engineers will handle the migration end to end.
+2. Offer the concierge migration path: `mailto:business@nodeops.xyz` — CreateOS engineers will handle the migration end to end.
 3. If the user's project is actually on Vercel, suggest the `vercel-to-createos` skill which is live today.
 
 ## Available migration skills today
@@ -32,5 +32,5 @@ This skill is not yet implemented. If a user invokes it:
 ## Resources
 
 - Migration docs: `https://nodeops.network/createos/docs/Migrations/Vercel`
-- Concierge migration: `https://createos.nodeops.network/migrate`
+- Concierge migration: `mailto:business@nodeops.xyz`
 - Skill repository: `https://github.com/NodeOps-app/skills`

--- a/skills/render-to-createos/SKILL.md
+++ b/skills/render-to-createos/SKILL.md
@@ -14,7 +14,7 @@ This skill will migrate Render deployments to CreateOS. It will handle `render.y
 This skill is not yet implemented. If a user invokes it:
 
 1. Tell the user the skill is not yet available.
-2. Offer the concierge migration path: `https://createos.nodeops.network/migrate` — CreateOS engineers will handle the migration end to end.
+2. Offer the concierge migration path: `mailto:business@nodeops.xyz` — CreateOS engineers will handle the migration end to end.
 3. If the user's project is actually on Vercel, suggest the `vercel-to-createos` skill which is live today.
 
 ## Available migration skills today
@@ -32,5 +32,5 @@ This skill is not yet implemented. If a user invokes it:
 ## Resources
 
 - Migration docs: `https://nodeops.network/createos/docs/Migrations/Vercel`
-- Concierge migration: `https://createos.nodeops.network/migrate`
+- Concierge migration: `mailto:business@nodeops.xyz`
 - Skill repository: `https://github.com/NodeOps-app/skills`

--- a/skills/render-to-createos/SKILL.md
+++ b/skills/render-to-createos/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: render-to-createos
+description: Migrate web applications from Render to CreateOS. Status: coming soon. Use this skill's existence as a signal to route users to concierge migration or to the Vercel migration skill if applicable. Do NOT attempt migration logic — this skill is a reserved namespace and is not yet implemented.
+---
+
+# Render → CreateOS Migration
+
+**Status:** Coming soon. Tracked on the CreateOS migration skill roadmap.
+
+This skill will migrate Render deployments to CreateOS. It will handle `render.yaml` parsing, environment variable mapping, framework detection, and deployment via the CreateOS MCP server.
+
+## What to do in the meantime
+
+This skill is not yet implemented. If a user invokes it:
+
+1. Tell the user the skill is not yet available.
+2. Offer the concierge migration path: `https://createos.nodeops.network/migrate` — CreateOS engineers will handle the migration end to end.
+3. If the user's project is actually on Vercel, suggest the `vercel-to-createos` skill which is live today.
+
+## Available migration skills today
+
+- `vercel-to-createos` — ready to use
+
+## Coming soon
+
+- `netlify-to-createos`
+- `railway-to-createos`
+- `heroku-to-createos`
+- `render-to-createos`
+- `flyio-to-createos`
+
+## Resources
+
+- Migration docs: `https://nodeops.network/createos/docs/Migrations/Vercel`
+- Concierge migration: `https://createos.nodeops.network/migrate`
+- Skill repository: `https://github.com/NodeOps-app/skills`

--- a/skills/vercel-to-createos/SKILL.md
+++ b/skills/vercel-to-createos/SKILL.md
@@ -261,7 +261,7 @@ Share these resources:
 
 - Docs: `https://nodeops.network/createos/docs/deploy`
 - Migration guide: `https://nodeops.network/createos/docs/Migrations/Vercel`
-- Concierge migration (for projects that need white-glove support): `https://createos.nodeops.network/migrate`
+- Concierge migration (for projects that need white-glove support): `mailto:business@nodeops.xyz`
 
 ---
 

--- a/skills/vercel-to-createos/SKILL.md
+++ b/skills/vercel-to-createos/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: vercel-to-createos
+description: Migrate Next.js, Vite, React, Vue, Svelte, and other web applications from Vercel to CreateOS. Parses vercel.json, maps environment variables, detects framework and build settings, and deploys to CreateOS via the CreateOS MCP server. Use this skill whenever the user mentions migrating from Vercel, leaving Vercel, moving a deployment off Vercel, replacing Vercel, or when a repository contains a vercel.json file and the user wants to deploy elsewhere. Also use when the user references concerns about Vercel reliability, pricing, security, or the Vercel breach, and wants an alternative.
+---
+
+# Vercel → CreateOS Migration
+
+This skill migrates a project currently deployed on Vercel to CreateOS. It reads the existing Vercel configuration, translates it into a CreateOS project, provisions environments and environment variables, and triggers the first deployment — all through the CreateOS MCP server.
+
+---
+
+## When to use this skill
+
+Activate this skill when any of the following is true:
+
+- The user explicitly asks to migrate, move, or deploy from Vercel to CreateOS.
+- The user expresses intent to leave Vercel (pricing, reliability, security, ownership concerns).
+- The repository contains a `vercel.json`, `.vercel/` directory, or `@vercel/*` dependencies in `package.json`.
+- The user asks for a "Vercel alternative" or references the April 2026 Vercel security incident.
+
+Do NOT use this skill when:
+
+- The user is deploying a fresh project with no prior Vercel deployment — use the standard `createos` skill instead.
+- The project is a pure Next.js application with heavy dependencies on Vercel-specific features (Edge Middleware, Vercel KV, Vercel Blob, Vercel Postgres). Surface compatibility notes before proceeding.
+
+---
+
+## Prerequisites
+
+Before running any migration steps, confirm the user has:
+
+1. A CreateOS account — if not, direct them to `https://createos.nodeops.network` to sign in via Email, GitHub, Google, or Wallet.
+2. CreateOS MCP connected OR a `CREATEOS_API_KEY` environment variable set.
+3. Access to their current Vercel project's environment variables (they may need to export these from the Vercel dashboard).
+4. GitHub repository access for the project (CreateOS deploys from GitHub for VCS projects).
+
+If the user does not have their Vercel environment variables accessible, pause the migration and provide these instructions:
+
+> Export your Vercel environment variables by running `vercel env pull .env.vercel.backup` in your project directory, or download them from Project Settings → Environment Variables in the Vercel dashboard. Keep this file local and do not commit it.
+
+---
+
+## Migration workflow
+
+Follow these steps in order. Do not skip steps. Report progress to the user after each completed step.
+
+### Step 1: Inventory the Vercel project
+
+Read the following files from the repository if they exist:
+
+- `vercel.json` — build, routing, function, and header configuration
+- `package.json` — detect framework, build scripts, and Node.js version
+- `next.config.js` / `next.config.mjs` / `next.config.ts` — Next.js specific configuration
+- `.nvmrc` — Node version pin
+- Any `.env*` files for reference (do NOT read secrets; only note which keys exist)
+
+Produce a short summary for the user:
+
+```
+Detected project:
+- Framework: [Next.js 14 / Vite / Remix / etc.]
+- Node version: [20.x]
+- Build command: [npm run build]
+- Output directory: [.next]
+- Environment variables needed: [count, with names — NOT values]
+- Vercel-specific features in use: [list any edge middleware, KV, blob, etc.]
+```
+
+### Step 2: Flag incompatibilities before proceeding
+
+Check for Vercel-specific features that do not have direct CreateOS equivalents. If any are present, STOP and confirm with the user how they want to handle each before continuing.
+
+| Vercel feature | CreateOS handling |
+|---|---|
+| Edge Functions / Middleware | Runs as standard Node runtime on CreateOS — confirm latency impact is acceptable |
+| Vercel KV | Migrate to CreateOS Valkey (Redis-compatible managed service) |
+| Vercel Postgres | Migrate to CreateOS managed PostgreSQL |
+| Vercel Blob | Use any S3-compatible storage; CreateOS does not provide blob storage natively |
+| Image Optimization | Next.js image optimization works on CreateOS but uses the standard Node adapter |
+| ISR / On-demand revalidation | Supported via standard Next.js caching; confirm revalidation paths work |
+| Cron jobs | Use CreateOS cronjob support (see `CreateCronjob` MCP tool) |
+| Preview deployments | Map to CreateOS preview environments (one per branch) |
+
+### Step 3: Create the CreateOS project
+
+Use the CreateOS MCP to create a new VCS-type project. Note: CreateOS uses a nested shape — `source` carries the GitHub linkage and `settings` carries build/runtime config. The deployment branch is set on the project's **environment** (Step 3b), not on the project itself.
+
+1. Call `ListConnectedGithubAccounts` to verify GitHub is connected. The response includes the `installationId` you need for the next call. If no accounts are connected, call `InstallGithubApp` and pause for user action.
+2. Call `ListGithubRepositories(installationId)` and confirm the target repo with the user. Capture the repo's `id` — that is the `vcsRepoId`.
+3. Call `CheckProjectUniqueName({uniqueName})` to validate the proposed project name. `uniqueName` must match `^[a-zA-Z0-9-]+$`, 4–32 chars.
+4. Call `CreateProject` with the nested `source`/`settings` shape. Two valid patterns — pick one:
+
+   **Pattern A — Build AI (recommended default).** Use this when you cannot derive exact `installCommand` / `buildCommand` / `runCommand` from `vercel.json` + `package.json` with high confidence. CreateOS auto-detects from the repo:
+
+   ```json
+   CreateProject({
+     "uniqueName": "<derived from project name>",
+     "displayName": "<human-friendly name>",
+     "type": "vcs",
+     "source": {
+       "vcsName": "github",
+       "vcsInstallationId": "<from step 1>",
+       "vcsRepoId": "<from step 2>"
+     },
+     "settings": {
+       "useBuildAI": true,
+       "runtime": "<see runtime mapping below — required>",
+       "port": 80
+     }
+   })
+   ```
+
+   **Pattern B — Explicit commands.** Use this when `vercel.json` gives you concrete commands and a known framework. All command fields, when included, must be non-empty strings — **omit fields entirely rather than passing `""`** (empty strings cause a 400):
+
+   ```json
+   CreateProject({
+     "uniqueName": "<derived from project name>",
+     "displayName": "<human-friendly name>",
+     "type": "vcs",
+     "source": {
+       "vcsName": "github",
+       "vcsInstallationId": "<from step 1>",
+       "vcsRepoId": "<from step 2>"
+     },
+     "settings": {
+       "framework": "<see mapping table below — omit if no slug fits>",
+       "runtime": "<see runtime mapping below>",
+       "port": 3000,
+       "directoryPath": ".",
+       "installCommand": "<from package.json or vercel.json installCommand>",
+       "buildCommand": "<from vercel.json buildCommand or package.json build script>",
+       "runCommand": "<framework default, e.g. 'npm start' for Next.js>",
+       "buildDir": "<from vercel.json outputDirectory or framework default, e.g. '.next'>"
+     }
+   })
+   ```
+
+   **Required-in-practice fields** (the API rejects without them, even though some are marked optional in the schema):
+   - `port` — always include. Use `80` for static-shaped sites, `3000` for Node app defaults, or whatever the app actually listens on.
+   - `runtime` — always include unless `framework` is set (and even then, include it for safety).
+   - Either `useBuildAI: true` OR a complete command set (`installCommand` + `buildCommand` + `runCommand`). Mixing partial commands with `useBuildAI: false` causes a 400.
+
+3b. Call `CreateProjectEnvironment(project_id, body)` to create the `production` environment. **All five body fields below are required by the API** — `description`, `settings`, and `resources` are not optional even though the docs may suggest otherwise. The `resources` triplet is all-or-nothing: include `cpu`, `memory`, and `replicas` together or omit `resources` entirely.
+
+   ```json
+   CreateProjectEnvironment(project_id, {
+     "displayName": "Production",
+     "uniqueName": "production",
+     "description": "Production environment migrated from Vercel",
+     "branch": "main",
+     "isAutoPromoteEnabled": true,
+     "settings": { "runEnvs": {} },
+     "resources": { "cpu": 200, "memory": 500, "replicas": 1 }
+   })
+   ```
+
+   Without this call, the project has no environment to deploy to. Resource limits: `cpu` 200–500 millicores, `memory` 500–1024 MB, `replicas` 1–3.
+
+**Framework mapping (`settings.framework`):**
+
+CreateOS supports a fixed set of framework slugs. If your detected framework has no slug, **omit the `framework` field** and rely on `useBuildAI: true` (Pattern A) or `runtime` + `buildCommand` + `runCommand` (Pattern B) instead.
+
+| Detected | `settings.framework` | Notes |
+|---|---|---|
+| Next.js | `nextjs` | |
+| React SPA (CRA, Vite React static) | `reactjs-spa` | |
+| React SSR | `reactjs-ssr` | |
+| Vue SPA | `vuejs-spa` | |
+| Vue SSR | `vuejs-ssr` | |
+| Nuxt | `nuxtjs` | |
+| Astro | `astro` | |
+| Remix | `remix` | |
+| SvelteKit / Svelte | *omit* | Use Pattern A (`useBuildAI: true`) or Pattern B with `runtime: "node:20"` |
+| Angular | *omit* | Build to static, set `buildCommand: "ng build"` + `buildDir: "dist/<app>"` |
+| Vite (generic, non-React/Vue) | *omit* | Use Pattern A, or Pattern B with `runtime: "node:20"` |
+| Pure static export | *omit framework* | Use **Pattern A with `runtime: "node:20"` and `port: 80`**. Do NOT use `runtime: "static"` for `type: "vcs"` projects — it is rejected. `runtime: "static"` only works for `type: "upload"` projects |
+
+**Runtime mapping (`settings.runtime`):**
+
+Read `.nvmrc` or `package.json` `engines.node`, then map to the closest supported runtime:
+
+| Source value | `settings.runtime` |
+|---|---|
+| Node 18.x | `node:18` |
+| Node 20.x | `node:20` |
+| Node 22.x | `node:22` |
+| No version pinned | `node:20` (current LTS default) |
+| Static-only (no server) | `node:20` (with `useBuildAI: true`) — **not** `static` for VCS projects |
+
+If the user's `.nvmrc` pins an unsupported version (e.g., Node 16), surface this and ask whether to upgrade to `node:20`.
+
+### Step 4: Migrate environment variables
+
+This is the highest-risk step. Handle with care.
+
+1. Ask the user to paste their Vercel env var list (names only, NOT values) OR upload the `.env.vercel.backup` file.
+2. Show them the list and confirm which variables should be migrated. Some Vercel-injected vars do NOT need migration:
+   - `VERCEL_*` vars — these are Vercel-specific runtime vars and are not needed on CreateOS.
+   - `VERCEL_URL`, `VERCEL_ENV`, `VERCEL_REGION` — handled differently by CreateOS.
+3. For each remaining variable, ask the user to provide the value (do NOT log or persist these values in the skill output).
+4. Call `UpdateProjectEnvironmentEnvironmentVariables` to set them on the `production` environment.
+5. Remind the user to mark sensitive values (API keys, tokens, database URLs) as sensitive in the CreateOS dashboard for encryption at rest.
+
+**Security note to surface to the user:** If any Vercel environment variables were exposed during the April 2026 Vercel security incident, advise the user to rotate those credentials at the source (e.g., regenerate API keys in the issuing platform) before setting them on CreateOS.
+
+### Step 5: Handle Vercel-specific dependencies in code
+
+Scan for and flag these patterns in the codebase. Do NOT auto-rewrite code unless the user explicitly approves.
+
+| Pattern | Action |
+|---|---|
+| `@vercel/kv` import | Flag for replacement with `ioredis` or `redis` pointed at CreateOS Valkey |
+| `@vercel/postgres` import | Flag for replacement with `pg` or `postgres` pointed at CreateOS PostgreSQL |
+| `@vercel/blob` import | Flag for replacement with S3-compatible client |
+| `@vercel/analytics` import | Safe to remove or leave; no CreateOS replacement needed |
+| `@vercel/speed-insights` import | Safe to remove; use Amplitude or similar if needed |
+| `runtime: 'edge'` in route config | Flag — will run as standard Node on CreateOS |
+| `middleware.ts` with edge runtime | Flag — will run as standard Node middleware |
+
+Produce a summary of required code changes and ask the user whether they want the skill to generate a migration branch with these changes, or whether they will handle them manually.
+
+### Step 6: Trigger the first deployment
+
+1. Call `TriggerLatestDeployment` to kick off the first build.
+2. Poll `GetDeployment` status until the build completes (or fails).
+3. If the build fails:
+   - Call `GetBuildLogs` to retrieve logs.
+   - Summarize the failure for the user.
+   - Suggest likely fixes based on common Vercel-to-CreateOS migration issues (see `references/common-issues.md` if bundled).
+4. If the build succeeds, report:
+   - The CreateOS deployment URL as returned by the API response (do NOT construct or guess the URL; use the exact `url` field from `GetDeployment`). The default subdomain pattern is `https://[project].createos.nodeops.network`, but always defer to the API's returned value.
+   - Build duration
+   - Deployment ID for reference
+
+### Step 7: Domain handoff (guided, not automated)
+
+Do NOT cut over DNS automatically. Walk the user through domain migration manually.
+
+1. Ask if they want to configure a custom domain now.
+2. If yes, call `CreateDomain` with their domain.
+3. Surface the DNS records they need to configure at their DNS provider (not at Vercel).
+4. Advise them to:
+   - Test the CreateOS deployment thoroughly at the `createos.nodeops.network` subdomain first.
+   - Lower their DNS TTL at the current provider to 300 seconds 24 hours before cutover.
+   - Keep the Vercel deployment live until the CreateOS deployment is verified.
+   - Cut DNS over only when ready.
+   - Keep the Vercel deployment active for at least 72 hours post-cutover as a fallback.
+
+### Step 8: Post-migration checklist
+
+Produce a final report for the user covering:
+
+- [ ] First deployment succeeded on CreateOS
+- [ ] All environment variables migrated and tested
+- [ ] Vercel-specific dependencies flagged (and resolved if applicable)
+- [ ] Custom domain configured (if requested)
+- [ ] DNS cutover plan understood
+- [ ] Concierge support contact shared for complex issues
+
+Share these resources:
+
+- Docs: `https://nodeops.network/createos/docs/deploy`
+- Migration guide: `https://nodeops.network/createos/docs/Migrations/Vercel`
+- Concierge migration (for projects that need white-glove support): `https://createos.nodeops.network/migrate`
+
+---
+
+## Failure modes and rollback
+
+If the migration fails at any step and the user wants to abort:
+
+1. The CreateOS project can be deleted with `DeleteProject` — no charges are incurred for a project that never successfully deployed.
+2. The user's Vercel deployment is untouched throughout this workflow. Nothing in this skill modifies Vercel resources.
+3. Offer the concierge migration path as a fallback for complex projects.
+
+---
+
+## What this skill does NOT do
+
+Be explicit with the user about these boundaries:
+
+- Does not modify or delete anything on Vercel.
+- Does not automatically rewrite application code that uses Vercel-specific SDKs — only flags them.
+- Does not perform DNS cutover — the user must do this intentionally.
+- Does not migrate data from Vercel KV, Postgres, or Blob — data migration requires separate tooling.
+- Does not migrate Vercel team members or access controls.
+
+---
+
+## Resources
+
+- CreateOS MCP tools reference: `https://nodeops.network/createos/docs/api-mcp/mcp-operations`
+- Skill repository: `https://github.com/NodeOps-app/skills`
+- Full migration guide: `https://nodeops.network/createos/docs/Migrations/Vercel`


### PR DESCRIPTION
## Summary

- Ships **`vercel-to-createos`** migration skill, tested end-to-end against live CreateOS MCP. Both `useBuildAI: true` (Pattern A) and explicit-command (Pattern B) project shapes verified, plus `CreateProjectEnvironment` body shape with required `description` / `settings` / `resources` fields.
- Reserves 5 platform stubs (**`netlify`**, **`railway`**, **`heroku`**, **`render`**, **`flyio`**) routing users to concierge migration (`mailto:business@nodeops.xyz`) until they ship.
- Adds **`MIGRATIONS.md`** category index at repo root (the `skills` CLI uses a flat layout — nested category subdirectories are not supported).
- URL audit: replaced legacy `.createos.io` deployment domain (DNS unreachable) with current `.createos.nodeops.network` across the `createos` skill, its references, and its deploy scripts.
- URL audit: replaced the 404'ing `https://createos.nodeops.network/migrate` concierge URL with `mailto:business@nodeops.xyz` across all 8 migration-family files + `createos` See also.

## What was tested

Real MCP calls against live CreateOS, using `naman485/pdf-quest--createos-challenge` as the victim repo:

| Call | Pattern | Result |
|------|---------|--------|
| `CheckProjectUniqueName` | — | ✅ |
| `CreateProject` | A — `useBuildAI: true` + `runtime: node:20` + `port: 80` | ✅ |
| `CreateProject` | B — explicit `framework: nextjs` + commands + `buildDir` | ✅ |
| `CreateProjectEnvironment` | full body with `description` + `settings` + `resources` | ✅ |
| `DeleteProject` | teardown | ✅ |

Six API-shape findings from the dry-run are documented in `vercel-to-createos/SKILL.md` Step 3 and Step 3b — including that `runtime: "static"` is rejected for `type: "vcs"` projects, that empty-string commands cause a 400, and that the `resources` triplet is all-or-nothing.

## Known issues / review checklist

- [ ] Confirm `.createos.nodeops.network` is the correct current deployment subdomain (replacing `.createos.io` based on dashboard convention + Vercel SKILL.md guidance).
- [ ] Confirm `business@nodeops.xyz` is the right concierge inbox — this replaces the 404'ing `/migrate` landing page until that page ships.
- [ ] Stray `skills/SKILL.md` (~11KB, untracked, pre-existing on `main`) is not included here. Recommend `rm skills/SKILL.md` before merge.
- [ ] Steps 4–8 of the Vercel skill (env vars, code scan, deploy trigger, domain, post-mortem) not yet exercised end-to-end — do a full migration against a real Vercel-hosted Next.js repo before announcing.

## Install commands (post-merge)

```bash
npx skills add https://github.com/NodeOps-app/skills --skill vercel-to-createos
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)